### PR TITLE
Fixed amenity related routes to use path variable in URI instead.

### DIFF
--- a/src/main/java/com/dart/explore/controller/StationController.java
+++ b/src/main/java/com/dart/explore/controller/StationController.java
@@ -22,7 +22,7 @@ public class StationController {
     @Autowired
     StationServiceImpl stationService;
 
-    @GetMapping(value = {"/poi/amenity/", "/poi/amenity/{amenitiesString}"})
+    @GetMapping(value = {"/poi/amenity", "/poi/amenity/{amenitiesString}"})
     ResponseEntity<List<PointOfInterestDTO>> getPOIs(@PathVariable Optional<String> amenitiesStringOpt) {
         /* probably move this first bit to a utility class later */
         List<Long> amenityIdList = new ArrayList<>();

--- a/src/main/java/com/dart/explore/controller/StationController.java
+++ b/src/main/java/com/dart/explore/controller/StationController.java
@@ -10,34 +10,54 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 @RestController
-@RequestMapping(value = "/api")
+@RequestMapping(value = "/api/public")
 public class StationController {
     @Autowired
     StationServiceImpl stationService;
 
-    @GetMapping(value = "/public/poi")
-    ResponseEntity<List<PointOfInterestDTO>> getPOIs(@RequestBody List<Amenity> amenities) {
+    @GetMapping(value = {"/poi/amenity/", "/poi/amenity/{amenitiesString}"})
+    ResponseEntity<List<PointOfInterestDTO>> getPOIs(@PathVariable Optional<String> amenitiesStringOpt) {
+        /* probably move this first bit to a utility class later */
+        List<Long> amenityIdList = new ArrayList<>();
+        if(amenitiesStringOpt.isPresent()){
+            /* populate amenityIdList */
+            String amenitiesString = amenitiesStringOpt.get();
+            amenityIdList = Arrays.stream(amenitiesString.split(",")).map((s)->Long.parseLong(s)).collect(Collectors.toList());
+        }
+        List<Amenity> amenities = stationService.getAmenitiesById(amenityIdList);
         List<PointOfInterestDTO> pointOfInterestList = stationService.getPOIs(amenities);
         return new ResponseEntity<List<PointOfInterestDTO>>(pointOfInterestList, HttpStatus.OK);
     }
 
-    @GetMapping(value = "/public/station/{line}")
+    @GetMapping(value = "/station/{line}")
     ResponseEntity<List<StationDTO>> getStationsByLine(@PathVariable String line) {
         List<StationDTO> stations = stationService.getStationsByLine(StationColor.valueOf(line));
         return new ResponseEntity<List<StationDTO>>(stations, HttpStatus.OK);
     }
 
-    @GetMapping(value = "/public/poi/{station}")
+    @GetMapping(value = "/poi/{station}")
     ResponseEntity<List<PointOfInterestDTO>> getPOIsByStation(@PathVariable String station) {
         List<PointOfInterestDTO> pointOfInterestList = stationService.getPOIsByStation(station);
         return new ResponseEntity<List<PointOfInterestDTO>>(pointOfInterestList, HttpStatus.OK);
     }
 
-    @GetMapping(value = "/public/poi/{station}/amenity")
-    ResponseEntity<List<PointOfInterestDTO>> getPOIsAtStation(@PathVariable String station, @RequestBody List<Amenity> amenities) {
+    @GetMapping(value = {"/poi/{station}/amenity", "/poi/{station}/amenity/{amenitiesString}"})
+    ResponseEntity<List<PointOfInterestDTO>> getPOIsAtStation(@PathVariable String station, @PathVariable Optional<String> amenitiesStringOpt) {
+        /* probably move this first bit to a utility class later */
+        List<Long> amenityIdList = new ArrayList<>();
+        if(amenitiesStringOpt.isPresent()){
+            /* populate amenityIdList */
+            String amenitiesString = amenitiesStringOpt.get();
+            amenityIdList = Arrays.stream(amenitiesString.split(",")).map((s)->Long.parseLong(s)).collect(Collectors.toList());
+        }
+        List<Amenity> amenities = stationService.getAmenitiesById(amenityIdList);
         List<PointOfInterestDTO> pointOfInterestList = stationService.getPOIsAtStation(station, amenities);
         return new ResponseEntity<List<PointOfInterestDTO>>(pointOfInterestList, HttpStatus.OK);
     }

--- a/src/main/java/com/dart/explore/controller/StationController.java
+++ b/src/main/java/com/dart/explore/controller/StationController.java
@@ -22,14 +22,14 @@ public class StationController {
     @Autowired
     StationServiceImpl stationService;
 
-    @GetMapping(value = {"/poi/amenity", "/poi/amenity/{amenitiesString}"})
+    @GetMapping(value = {"/poi/amenity", "/poi/amenity/{amenitiesStringOpt}"})
     ResponseEntity<List<PointOfInterestDTO>> getPOIs(@PathVariable Optional<String> amenitiesStringOpt) {
-        /* probably move this first bit to a utility class later */
+        // probably move this first bit to a utility class later
         List<Long> amenityIdList = new ArrayList<>();
-        if(amenitiesStringOpt.isPresent()){
-            /* populate amenityIdList */
+        if (amenitiesStringOpt.isPresent()) {
+            // populate amenityIdList
             String amenitiesString = amenitiesStringOpt.get();
-            amenityIdList = Arrays.stream(amenitiesString.split(",")).map((s)->Long.parseLong(s)).collect(Collectors.toList());
+            amenityIdList = Arrays.stream(amenitiesString.split(",")).map(Long::parseLong).collect(Collectors.toList());
         }
         List<Amenity> amenities = stationService.getAmenitiesById(amenityIdList);
         List<PointOfInterestDTO> pointOfInterestList = stationService.getPOIs(amenities);
@@ -48,14 +48,14 @@ public class StationController {
         return new ResponseEntity<List<PointOfInterestDTO>>(pointOfInterestList, HttpStatus.OK);
     }
 
-    @GetMapping(value = {"/poi/{station}/amenity", "/poi/{station}/amenity/{amenitiesString}"})
+    @GetMapping(value = {"/poi/{station}/amenity", "/poi/{station}/amenity/{amenitiesStringOpt}"})
     ResponseEntity<List<PointOfInterestDTO>> getPOIsAtStation(@PathVariable String station, @PathVariable Optional<String> amenitiesStringOpt) {
-        /* probably move this first bit to a utility class later */
+        // probably move this first bit to a utility class later
         List<Long> amenityIdList = new ArrayList<>();
-        if(amenitiesStringOpt.isPresent()){
-            /* populate amenityIdList */
+        if (amenitiesStringOpt.isPresent()) {
+            // populate amenityIdList
             String amenitiesString = amenitiesStringOpt.get();
-            amenityIdList = Arrays.stream(amenitiesString.split(",")).map((s)->Long.parseLong(s)).collect(Collectors.toList());
+            amenityIdList = Arrays.stream(amenitiesString.split(",")).map(Long::parseLong).collect(Collectors.toList());
         }
         List<Amenity> amenities = stationService.getAmenitiesById(amenityIdList);
         List<PointOfInterestDTO> pointOfInterestList = stationService.getPOIsAtStation(station, amenities);

--- a/src/main/java/com/dart/explore/repository/AmenityRepository.java
+++ b/src/main/java/com/dart/explore/repository/AmenityRepository.java
@@ -1,8 +1,15 @@
 package com.dart.explore.repository;
 
 import com.dart.explore.entity.Amenity;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface AmenityRepository extends CrudRepository<Amenity, Long> {
-
+    @Query("SELECT a FROM Amenity a")
+    List<Amenity> findAllAmenities();
+    @Query("SELECT a FROM Amenity a WHERE a.amenityId IN :ids")
+    List<Amenity> findAllAmenitiesById(@Param("ids") List<Long> ids);
 }

--- a/src/main/java/com/dart/explore/service/StationService.java
+++ b/src/main/java/com/dart/explore/service/StationService.java
@@ -20,4 +20,6 @@ public interface StationService {
     List<PointOfInterestDTO> getPOIsByStation(String stationName);
 
     List<PointOfInterestDTO> getPOIsAtStation(String stationName, List<Amenity> amenities);
+
+    List<Amenity> getAmenitiesById(List<Long> amenityIdList);
 }

--- a/src/main/java/com/dart/explore/service/StationServiceImpl.java
+++ b/src/main/java/com/dart/explore/service/StationServiceImpl.java
@@ -1,11 +1,14 @@
 package com.dart.explore.service;
 
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import com.dart.explore.dto.PointOfInterestDTO;
 import com.dart.explore.dto.StationDTO;
 import com.dart.explore.entity.StationColor;
+import com.dart.explore.repository.AmenityRepository;
 import com.dart.explore.repository.PointOfInterestRepository;
 import com.dart.explore.repository.StationRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,6 +24,8 @@ public class StationServiceImpl implements StationService {
     PointOfInterestRepository pointOfInterestRepository;
     @Autowired
     StationRepository stationRepository;
+    @Autowired
+    AmenityRepository amenityRepository;
 
     @Override
     public List<PointOfInterestDTO> getPOIs(List<Amenity> amenities) {
@@ -42,4 +47,10 @@ public class StationServiceImpl implements StationService {
         return pointOfInterestRepository.getPointOfInterestsByStationAndAmenities(stationName, amenities).stream().map(PointOfInterestDTO::prepareDTO).collect(Collectors.toList());
     }
 
+    @Override
+    public List<Amenity> getAmenitiesById(List<Long> amenityIdList){
+        if(amenityIdList.isEmpty())
+            return amenityRepository.findAllAmenities();
+        return amenityRepository.findAllAmenitiesById(amenityIdList);
+    }
 }


### PR DESCRIPTION
I eliminated the use of RequestBody in the amenity related methods. Would like some feedback on the following:
- getPOIs is now mapped to the following URL: /poi/amenity/*
- getPOIsAtStation is now mapped to the following URL: /poi/{station}/amenity/*
- The amenities are encoded in a string of comma separated numbers. So for example calling /poi/amenity/1,2 gives the points of interest with amenities 1 and 2. If no ids are given then we retrieve all points of interest.
- Some methods are made in Amenity repository to convert the list of ids to a list of amenities but I would prefer to maybe query using the ids directly because there are some back and forth conversions going on.