### PR TITLE
Made amenity filter exclusive

### DIFF
--- a/src/main/java/com/dart/explore/controller/ReadController.java
+++ b/src/main/java/com/dart/explore/controller/ReadController.java
@@ -9,7 +9,6 @@ import com.dart.explore.service.AmenityService;
 import com.dart.explore.service.PointOfInterestService;
 import com.dart.explore.service.StationServiceImpl;
 import io.swagger.v3.oas.annotations.Parameter;
-import org.springframework.data.repository.query.Param;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -17,7 +16,6 @@ import org.springframework.web.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @RestController
@@ -50,7 +48,7 @@ public class ReadController {
         return new ResponseEntity<>(pointOfInterestList, HttpStatus.OK);
     }
 
-    @GetMapping(value="/poi/amenity")
+    @GetMapping(value = "/poi/amenity")
     ResponseEntity<List<PointOfInterestDTO>> getPOIs(@RequestParam("amenityIdList") String amenitiesString) {
         // probably move this first bit to a utility class later
         List<Long> amenityIdList = (amenitiesString.isEmpty()) ? new ArrayList<>() :
@@ -61,7 +59,7 @@ public class ReadController {
         return new ResponseEntity<List<PointOfInterestDTO>>(pointOfInterestList, HttpStatus.OK);
     }
 
-    @GetMapping(value ="/poi/{stationId}/amenity")
+    @GetMapping(value = "/poi/{stationId}/amenity")
     ResponseEntity<List<PointOfInterestDTO>> getPOIsAtStation(@PathVariable Long stationId, @RequestParam("amenityIdList") String amenitiesString) {
         // probably move this first bit to a utility class later
         List<Long> amenityIdList = (amenitiesString.isEmpty()) ? new ArrayList<>() :

--- a/src/main/java/com/dart/explore/repository/PointOfInterestRepository.java
+++ b/src/main/java/com/dart/explore/repository/PointOfInterestRepository.java
@@ -10,8 +10,9 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface PointOfInterestRepository extends CrudRepository<PointOfInterest, Long> {
-    @Query("SELECT p FROM PointOfInterest p JOIN p.amenities a WHERE a IN :amenities")
-    List<PointOfInterest> getPOIsByAmenities(@Param("amenities") List<Amenity> amenities);
+    @Query("SELECT p FROM PointOfInterest p JOIN p.amenities a WHERE a IN :amenities GROUP BY p HAVING COUNT(DISTINCT a) >= :amenityCount")
+    List<PointOfInterest> getPOIsByAmenities(@Param("amenities") List<Amenity> amenities, @Param("amenityCount") Long amenityCount);
+
 
     @Query("SELECT p FROM PointOfInterest p JOIN p.station s JOIN p.amenities a WHERE s.stationId = :stationId AND a IN :amenities")
     List<PointOfInterest> getPointOfInterestsByStationAndAmenities(@Param("stationId") Long stationId, @Param("amenities") List<Amenity> amenities);

--- a/src/main/java/com/dart/explore/service/StationServiceImpl.java
+++ b/src/main/java/com/dart/explore/service/StationServiceImpl.java
@@ -33,7 +33,10 @@ public class StationServiceImpl implements StationService {
 
     @Override
     public List<PointOfInterestDTO> getPOIs(List<Amenity> amenities) {
-        return pointOfInterestRepository.getPOIsByAmenities(amenities).stream().map(PointOfInterestDTO::prepareDTO).collect(Collectors.toList());
+        Long amenityCount = (long) amenities.size();
+        return pointOfInterestRepository.getPOIsByAmenities(amenities, amenityCount).stream()
+                .map(PointOfInterestDTO::prepareDTO)
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/src/test/java/com/dart/explore/integration/PointOfInterestRepositoryIT.java
+++ b/src/test/java/com/dart/explore/integration/PointOfInterestRepositoryIT.java
@@ -57,7 +57,10 @@ class PointOfInterestRepositoryIT {
 
     @Test
     public void whenGetPointOfInterestByAmenity_thenReturnPointOfInterest() {
-        List<PointOfInterest> foundPOIs = pointOfInterestRepository.getPOIsByAmenities(Collections.singletonList(testAmenity));
+        List<Amenity> amenities = Collections.singletonList(testAmenity);
+        Long amenityCount = (long) amenities.size();
+        List<PointOfInterest> foundPOIs = pointOfInterestRepository.getPOIsByAmenities(amenities, amenityCount);
+
         assertThat(foundPOIs).hasSize(1);
         assertThat(foundPOIs.get(0).getName()).isEqualTo(testPOI.getName());
     }


### PR DESCRIPTION
The amenity filter will only return POI that have at least all the provided amenities

This update works by doing a join on all of the amenities that match the set we provided. Once we have that table we group by POI to get a count of the amount of matching amenities, then we compare the count of our provided list with the count of the grouped POI and provide whichever one's have at least the same amount of amenities. 

I was able to confirm this working through swagger, but not through a local serving of our front end.

closes #191 